### PR TITLE
Docker Installation Option

### DIFF
--- a/Docker_Files/JET_dockerfile.txt
+++ b/Docker_Files/JET_dockerfile.txt
@@ -1,0 +1,53 @@
+FROM continuumio/anaconda3
+RUN conda create -n myenv python=3.6.2
+SHELL ["conda", "run", "-n", "myenv", "/bin/bash", "-c"]
+
+#Enable extra distribution channels for packages not included in basic conda
+RUN conda config --add channels conda-forge
+RUN conda config --add channels http://ssb.stsci.edu/astroconda
+
+#Install packages for JET via basic conda
+RUN conda install -y astropy=3.2.3
+RUN conda install -y matplotlib=2.2.2
+
+#Install packages for JET via conda forge channel
+RUN conda install -y -c conda-forge bokeh=0.12.6=py36_0
+RUN conda install -y -c conda-forge joblib=0.11=py36_0
+RUN conda install -y -c conda-forge pyfftw=0.10.4
+RUN conda install -y -c conda-forge scipy=1.0.0=py36_blas_openblas_201
+RUN conda install -y -c conda-forge sphinx=1.5.6
+	
+#Install packages for JET via http://ssb.stsci.edu/astroconda channel
+RUN conda install -y -c http://ssb.stsci.edu/astroconda photutils=0.4.1
+RUN conda install -y -c http://ssb.stsci.edu/astroconda pysynphot=0.9.8.8=py36_1
+RUN conda install -y -c http://ssb.stsci.edu/astroconda synphot=0.1.3
+
+#Install remaining packages with pip
+RUN python -m pip install numpy==1.14.0
+RUN python -m pip install pandeia.engine==1.4
+
+#Install build-essential to allow next package installation
+RUN apt-get update && apt-get install -y build-essential
+RUN python -m pip install pandexo.engine==1.3
+RUN python -m pip install pyephem==3.7.6.0
+RUN python -m pip install spectres==2.0.0
+
+#Install git
+RUN apt-get update && apt-get install -y git
+#Clone JET repository
+RUN git clone https://github.com/cdfortenbach/JET.git
+
+#Set working directory 
+WORKDIR /JET
+
+#Copy pandeia and Pandexo .tar files from user's computer (make sure the two .tar files are in the directory you ran docker from)
+COPY pandeia_data-1.4.tar.gz /JET/
+RUN tar -xvzf pandeia_data-1.4.tar.gz
+COPY synphot5.tar.gz /JET/
+RUN tar -xvzf synphot5.tar.gz
+
+
+
+
+
+

--- a/Docker_Files/JET_dockerfile.txt
+++ b/Docker_Files/JET_dockerfile.txt
@@ -17,7 +17,7 @@ RUN conda install -y -c conda-forge joblib=0.11=py36_0
 RUN conda install -y -c conda-forge pyfftw=0.10.4
 RUN conda install -y -c conda-forge scipy=1.0.0=py36_blas_openblas_201
 RUN conda install -y -c conda-forge sphinx=1.5.6
-	
+
 #Install packages for JET via http://ssb.stsci.edu/astroconda channel
 RUN conda install -y -c http://ssb.stsci.edu/astroconda photutils=0.4.1
 RUN conda install -y -c http://ssb.stsci.edu/astroconda pysynphot=0.9.8.8=py36_1
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y git
 #Clone JET repository
 RUN git clone https://github.com/cdfortenbach/JET.git
 
-#Set working directory 
+#Set working directory
 WORKDIR /JET
 
 #Copy pandeia and Pandexo .tar files from user's computer (make sure the two .tar files are in the directory you ran docker from)
@@ -46,9 +46,3 @@ COPY pandeia_data-1.4.tar.gz /JET/
 RUN tar -xvzf pandeia_data-1.4.tar.gz
 COPY synphot5.tar.gz /JET/
 RUN tar -xvzf synphot5.tar.gz
-
-
-
-
-
-

--- a/Docker_Files/JET_dockerfile.txt
+++ b/Docker_Files/JET_dockerfile.txt
@@ -1,4 +1,5 @@
 FROM continuumio/anaconda3
+LABEL maintainer='Emma Turtelboom, eturtelboom@berkeley.edu'
 RUN conda create -n myenv python=3.6.2
 SHELL ["conda", "run", "-n", "myenv", "/bin/bash", "-c"]
 

--- a/README.md
+++ b/README.md
@@ -28,68 +28,49 @@ The *James Webb Space Telescope* (*JWST*) will devote significant observing time
 
 * An effort to make the code more efficient would be helpful. In particular, consideration of processing multiple targets with a parallel processing architecture would seem to be a worthwhile development project; however, this idea has not been further addressed here.
 
-* The full JET code has a memory storage footprint of approximately 3.7 GB.  A production run of a 2000 target catalog will generate about 1 GB of output (spectra, and various tables).  So, you need to plan on a total memory storage requirement of at least 4.7 GB for a large survey run.  In execution you will need about 4 GB of free RAM on top of any other system requirements. 
+* The full JET code has a memory storage footprint of approximately 3.7 GB.  A production run of a 2000 target catalog will generate about 1 GB of output (spectra, and various tables).  So, you need to plan on a total memory storage requirement of at least 4.7 GB for a large survey run.  In execution you will need about 4 GB of free RAM on top of any other system requirements.
 
 ### Software Configuration/Installation
 * The desktop computer described in the previous section runs the Windows 7 Ultimate (SP1) operating system.  We chose to develop the JET suite of programs to run in a Linux environment.  We used Oracle VirtualBox software (5.1.26) to run a Linux guest OS (specifically Ubuntu 16.04) under the Windows 7 host.  Of course a dedicated Linux machine should work just fine.  The installation and execution instructions provided here assume that the user will be using a Linux OS.
 
 * The VirtualBox software allows files to be shared between the two OS's, which is very useful, but otherwise it keeps the two systems separate.  In order to implement the file sharing feature it was necessary to edit the system BIOS to enable the CPU's virtualization features.  Unfortunately, the details of the editing are different with different motherboards and CPU hardware so it is hard to give specifics here.  The key is to sort through the BIOS menus at boot up to find the CPU virtualization feature toggle and enable it.  Of course, if the JET suite is installed on a Linux machine in the first place there is no need to worry about virtualization software.
 
-* The JET code was written in Python 3.6.1/2.  It is highly recommended that you use Python 3.6.2 to run JET.
+*New*
+* We have used Docker to containerize the required packages for the JET code. Docker will serve a similar purpose in this case as conda environments do, by creating an isolated "container", where all the required package are installed without compromising any existing package dependencies or versions that you already have on your computer. Containers are based off of "images", and in this repo we include the instruction manual (a Dockerfile) for an image that includes the required software to run JET. The following instructions will use this manual to set up the JET code for your use.
 
-* JET has a number of Python dependencies (see Table 2); however, many of them will be satisfied by an up-to-date scientific Python installation.  Unless you actively maintain your own scientific Python distribution, we recommend installing the latest Anaconda Linux distribution (currently, as of 7-5-2019, for Python 3.7) and running the following command to downgrade to Python 3.6 in the root environment:
+1. Install Docker (https://www.docker.com/products/docker-desktop).
 
- ```conda install python=3.6.2```
+2. Once you have installed Docker, make sure that Docker Desktop (or Server for Linux users) is running.
 
-* To avoid conflicts, it is recommended that you first remove/uninstall any existing packages shown in Table 2 with the incorrect version/build.  You can see the packages available in your Anaconda distribution with the command:  ```conda list```.
+3. Next, you need to download certain data-files associated with PandExo/Pandeia.  The first is a set of files for Pandeia itself, which can be downloaded from: https://stsci.app.box.com/v/pandeia-refdata-v1p4.  Once the download is complete, move the tar file from your download folder to the JET/Docker_Files directory of this repository, which should already contain a file named JET_dockerfile.txt.
 
-* To remove packages that do not have the < pip > designation, you can use the command:
+4. Next, you will need to download another set of data-files associated with PandExo.  The second set of data-files are for pysynphot. Pandeia uses pysynphot internally for creating reference spectra. The pysynphot reference files may be downloaded from: https://archive.stsci.edu/pub/hst/pysynphot/.  We want to download **synphot5.tar.gz**.  Move the tar file from your download folder to the JET/Docker_Files directory.  
 
- ```conda remove package_name```
+5. In order to use Docker to create a container with the full environment required to run JET, navigate to the JET/Docker_Files directory in your terminal, and enter the command: ```docker build . -f ./JET_dockerfile.txt  -t jet_image``` This command will take ~20 minutes to run, with lots of outputs, and builds a Docker image based on JET_dockerfile.txt. You will create containers on top of this image, in which you can run JET code.
 
-* For packages with the < pip > designation, you can use the command:
+6. Check whether the image has been created by running ```docker images```, and seeing if one of the images listed is named jet_image.
 
- ```pip uninstall package_name```
+7. Create a container based on the "jet_image" image with the command ```docker container create -it jet_image```. This step can be repeated every time you wish to use JET, but please note that different containers will not include the same versions of files (i.e. an output file from a JET run in one container will not be present in another container based on the same image).
 
-* **Warning!**:  rolling back certain elements of your Python package distribution, may break other Python programs that are dependent on your existing package distribution.  It may make sense to use virtualenv (https://pypi.org/project/virtualenv/), a tool to create isolated Python environments.
+8. Use ```docker ps -a``` to get a list of all containers, and copy the name of the container you just created (usually two words separated by an underscore, e.g. "adequate_pandas").
 
-* For those packages that are not included in the basic conda distribution, you will need to enable certain additional distribution channels with:
+9. In order to "enter" a container and run the JET code, you will need to enter two commands: ```docker start CONTAINER``` and then ```docker attach CONTAINER```, where CONTAINER is the name of the container you copied in the step 8. Once you have run these two commands, your terminal will enter the container, where you can now run commands.
 
- ```conda config --add channels conda-forge```
- 
- and
- 
- ```conda config --add channels http://ssb.stsci.edu/astroconda```
+10. The first command you should run is ```source activate myenv```, in order to use the appropriate python version (Python 3.6.2).
 
- This only needs to be done once, not for each package.
+11. Navigate to the JET directory, which should contain the two .tar.gz files. These are in gzip form and can be unpacked in the working directory with the commands:
+ ```$ tar -xvzf pandeia_data-1.4.tar.gz```
+```$ tar -xvzf synphot5.tar.gz```
 
-* It is recommended that you install the version/build of the packages specified in Table 2. There are various complex dependencies and this build has been verified.  
+ Once the files are unpacked you should be left with a folder/directory named **pandeia_data-1.4**, **grp**, and the tar files.  The tar files can then be deleted.
 
-* Many of the required packages (unless they have < pip > in the build column of Table 2) can then be installed from the Linux command line with:
+ Your working directory should now have all of the necessary elements of JET, including all files and folders associated with Exo-Transmit and PandExo. Of course it is possible to download the latest version of Exo-Transmit (source code) from GitHub (see https://github.com/elizakempton/Exo_Transmit), but for simplicity we have chosen to include a fully compiled, and tested version of Exo-Transmit as part of the JET download.  There are also some minor changes to a couple of the baseline Exo-Transmit data-files that we have made for JET to work properly.
 
- ```conda install package_name=version=build_string```
- 
- For example:
- 
- ```conda install joblib=0.11=py36_0```
- 
-* For those packages with a non-conda channel, you should use the command:
+  In some cases, high-metallicity atmospheres in particular, can be optically thick all the way to the very top of the atmosphere, at certain wavelengths.  This will cause a hard cutoff of the spectrum at a specific transit depth.  To extend the atmosphere to higher levels (i.e., lower pressures), more lines have been added to the original release T-P files (we went from 333 to 533 lines), extending the decaying exponential to lower pressure.  The number of optical depth points given in the file: **otherInput.in**, has also been be modified to give the correct number of lines for the new T-P files.  You should not need to edit these files further.
 
- ```conda install -c channel package_name=version=build_string```
+  There are several input files associated with Exo-Transmit that have not been described in detail (e.g., **selectChem.in**, **otherInput.in**, and **userInput.in**).  For our purposes these should not have to be disturbed by the user; however, it is possible to make changes to these if necessary.  Further details can be found in the Exo-Transmit user manual included in this repository, or at https://github.com/elizakempton/Exo_Transmit.
 
- For example:
-
- ```conda install -c conda-forge astropy=3.2.3```
- 
- or another example:
- 
- ```conda install -c http://ssb.stsci.edu/astroconda photutils=0.4.1```
-
-* For the remaining packages, you will need to use the pip package manager.  For example, to install numpy use the command:
-
- ```pip install numpy=1.14.0``` 
-
-* When this process has been completed for all of the required packages, again use the Linux command ```conda list``` to verify that all packages and modules shown in Table 2 are installed:
+12. When this process has been completed for all of the required packages, again use the Linux command ```conda list``` to verify that all packages and modules shown in Table 2 are installed:
 
  Table 2. Python Packages/Modules for JET Installation
 
@@ -111,27 +92,8 @@ The *James Webb Space Telescope* (*JWST*) will devote significant observing time
 | sphinx                | Python pkg.       | 1.5.6                                  | conda-forge                         |
 | synphot               | Python pkg.       | 0.1.3                                  | http://ssb.stsci.edu/astroconda     |
 
-### Installing the JET Code
 
-1. Now, choose/create a working directory for the JET code within your Linux system file structure.
-
-2. Open a terminal in your Linux Download directory.  Then, download the JET repository tar file from GitHub with the command: 
-
- ```curl -L https://github.com/cdfortenbach/JET/tarball/master > master``` 
-
-   This is a big file, so it may take a few minutes.  You should eventually see a folder/directory called **master** appear in the Download directory.
-
-3. Now, unpack the **master** tar file with the command: 
-
- ```tar -xvzf master``` 
- 
-   you should now see a new folder/directory called **cdfortenbach-JET-*commitID#***.   
-
-4. Open this folder/directory and move the contents to your working directory.  
-
-5. The downloaded tar file (**master**), and the now empty folder/directory **cdfortenbach-JET-*commitID#*** can be deleted.  
-
-6. You should verify that you have all files and folders listed in Table 3.
+13. You should also verify that you have all files and folders listed in Table 3 in the JET directory in your container.
 
  Table 3. Files and Folders in JET Working Directory
 
@@ -162,58 +124,42 @@ The *James Webb Space Telescope* (*JWST*) will devote significant observing time
 | target_survey.txt           | .txt file in format of the "Sullivan" survey .mrt                                        |
 | userInput.in                | internal transfer file assoc. with Exo-Transmit                                          |
 
+ You can now interact with the JET code in this container. When you would like to finish using the code, use the command ```exit``` to leave the Docker container and return to your current working directory. When you would like to use the JET code again, please repeat Steps 9-15.
 
-7. Next, you need to download certain data-files associated with PandExo/Pandeia.  The first is a set of files for Pandeia itself, which can be downloaded from: https://stsci.app.box.com/v/pandeia-refdata-v1p4.  Once the download is complete, move the tar file from your download folder to the JET working directory.  This is in gzip form and can be unpacked in the working directory. Use the command: 
-
- ```$ tar -xvzf pandeia_data-1.4.tar.gz```  
-
-  to unpack the tar file. Once the files are unpacked you should be left with a folder/directory named **pandeia_data-1.4**.  The tar file can then be deleted.
-
-8. Next, you will need to download another set of data-files associated with PandExo.  The second set of data-files are for pysynphot. Pandeia uses pysynphot internally for creating reference spectra. The pysynphot reference files may be downloaded from: https://archive.stsci.edu/pub/hst/pysynphot/.  We want to download **synphot5.tar.gz**.  Move the tar file from your download folder to the JET working directory.  This is also in gzip form and can be unpacked in the working directory with the command: 
-
- ```$ tar -xvzf synphot5.tar.gz```
-
-  Once the files are unpacked you should be left with a folder/directory named **grp** and the tar file.  The tar file can be deleted.
-
- Your working directory should now have all of the necessary elements of JET, including all files and folders associated with Exo-Transmit and PandExo. Of course it is possible to download the latest version of Exo-Transmit (source code) from GitHub (see https://github.com/elizakempton/Exo_Transmit), but for simplicity we have chosen to include a fully compiled, and tested version of Exo-Transmit as part of the JET download.  There are also some minor changes to a couple of the baseline Exo-Transmit data-files that we have made for JET to work properly. 
-
-  In some cases, high-metallicity atmospheres in particular, can be optically thick all the way to the very top of the atmosphere, at certain wavelengths.  This will cause a hard cutoff of the spectrum at a specific transit depth.  To extend the atmosphere to higher levels (i.e., lower pressures), more lines have been added to the original release T-P files (we went from 333 to 533 lines), extending the decaying exponential to lower pressure.  The number of optical depth points given in the file: **otherInput.in**, has also been be modified to give the correct number of lines for the new T-P files.  You should not need to edit these files further.
-
-  There are several input files associated with Exo-Transmit that have not been described in detail (e.g., **selectChem.in**, **otherInput.in**, and **userInput.in**).  For our purposes these should not have to be disturbed by the user; however, it is possible to make changes to these if necessary.  Further details can be found in the Exo-Transmit user manual included in this repository, or at https://github.com/elizakempton/Exo_Transmit.
- 
-9. It is recommended that the user edit certain print statements in the **PandExo.engine** (installed as a Python package in the Anaconda directory) that are unnecessary and time consuming in our long, many-target runs. Specifically, we recommend that you "comment out" (add leading # character to the line) the following lines in **justdoit.py** and **jwst.py**:
+14. It is recommended that the user edit certain print statements in the **PandExo.engine** (installed as a Python package in the Anaconda directory) that are unnecessary and time consuming in our long, many-target runs. Specifically, we recommend that you "comment out" (add leading # character to the line) the following lines in **justdoit.py** and **jwst.py**:
 
     anconda3/lib/python3.6/site-packages/pandexo/engine/justdoit.py - line 267
     	should be:   ```#print("Running Single Case for: " + inst[0])```
-  
+
     anconda3/lib/python3.6/site-packages/pandexo/engine/jwst.py - line 153
     	should be:   ```#print("Optimization Reqested: Computing Duty Cycle")```
-  
+
     anconda3/lib/python3.6/site-packages/pandexo/engine/jwst.py - line 156
     	should be:   ```#print("Finished Duty Cycle Calc")```
-  
+
     anconda3/lib/python3.6/site-packages/pandexo/engine/jwst.py - line 162
     	should be:   ```#print("Starting Out of Transit Simulation")```
-  
+
     anconda3/lib/python3.6/site-packages/pandexo/engine/jwst.py - line 169
     	should be:   ```#print("End out of Transit")```
-  
+
     anconda3/lib/python3.6/site-packages/pandexo/engine/jwst.py - line 176
     	should be:   ```#print("Starting In Transit Simulation")```
-  
+
     anconda3/lib/python3.6/site-packages/pandexo/engine/jwst.py - line 178
     	should be:   ```#print("End In Transit")```
-  
-10. That’s it!  You have completed the JET installation.
+
+15. That’s it!  You have completed the JET installation.
 
 
 ### Executing the program
 
 The following step-by-step process should guide you through making a run with the JET code:
 
-1.  First, using a GUI (e.g., Ubuntu, etc.) or with a Linux terminal, navigate to the JET working directory.
+1.  First, using a GUI (e.g., Ubuntu, etc.) or with a Linux terminal and Docker commands ```docker start CONTAINER``` and ```docker attach CONTAINER```, navigate to the JET working directory.
 
-2.  If you want to start fresh, then the folders **dBIC**, **Spectra**, **Pdxo_Output_archive**, and **JET_Smry_tables** should be cleaned out for a new run.  Any files in these folders/directories can be saved elsewhere as appropriate. The dummy **README** file in each of these folder/directories can be left in place.
+2.  If you want to start fresh, then the folders **dBIC**, **Spectra**, **Pdxo_Output_archive**, and **JET_Smry_tables** should be cleaned out for a new run. Any files in these folders/directories can be saved elsewhere on your local machine as appropriate, by using the command ```docker cp CONTAINER:SRC_PATH DEST_PATH|-``` (https://docs.docker.com/engine/reference/commandline/cp/). The dummy **README** file in each of these folder/directories can be left in place. Alternatively, you can create a new container starting at Step 7 in the Software Installation.
+*endnew*
 
 3.  Using a .txt editor (or development environment), open the **JET_Input.txt** file and make the appropriate changes to the input parameters.  The following shows an example set-up for a run with NIRSpec G395M.  Only the boldface parameters should be changed.  Only make changes to User Input values in rows 7 - 46, and cols 60 - 79!!   Do not change the syntax for any item.  This is a comma delimited file.  Commas should only be included where indicated.
 
@@ -222,47 +168,47 @@ The following step-by-step process should guide you through making a run with th
 | Parameter Description                                    | User Input                |
 |:---------------------------------------------------------|:--------------------------|
 | Starting target from catalog for this run:               |, **5**|   
-| Ending target from catalog:                              |, **7**| 
-|                                                          |                           | 
-| JWST instrument:                                         |, **NIRSpec G395M**| 
-| Wavelength short limit (microns):                        |, **2.87**| 
-| Wavelength long limit (microns):                         |, **5.18**| 
-| Jmag limit (Teff = 10000K):                              |, **6.2**| 
-| Jmag limit (Teff = 5000K):                               |, **6.8**| 
-| Jmag limit (Teff = 2500K):                               |, **7.4**| 
-| Detector linear response limit (% FW):                   |, **80**| 
-| Noise floor (nfloor) (ppm):                              |, **25**| 
-| R value of sim (Res):                                    |, **100**| 
-| Number of dBIC samples for each ntr grid pt.:            |, **2000**| 
-| Detection threshold (dBIC):                              |, **10**| 
-| Free model spectrum BIC parameters:                      |, **5**| 
+| Ending target from catalog:                              |, **7**|
 |                                                          |                           |
-| Eq. of State (lo metal atm):                             |, **eos_5Xsolar_cond**| 
-| Cloud_lo (Pa):                                           |, **0**| 
-| Eq. of State (hi metal atm):                             |, **eos_1000Xsolar_cond**| 
-| Cloud_hi (Pa):                                           |, **10000**| 
+| JWST instrument:                                         |, **NIRSpec G395M**|
+| Wavelength short limit (microns):                        |, **2.87**|
+| Wavelength long limit (microns):                         |, **5.18**|
+| Jmag limit (Teff = 10000K):                              |, **6.2**|
+| Jmag limit (Teff = 5000K):                               |, **6.8**|
+| Jmag limit (Teff = 2500K):                               |, **7.4**|
+| Detector linear response limit (% FW):                   |, **80**|
+| Noise floor (nfloor) (ppm):                              |, **25**|
+| R value of sim (Res):                                    |, **100**|
+| Number of dBIC samples for each ntr grid pt.:            |, **2000**|
+| Detection threshold (dBIC):                              |, **10**|
+| Free model spectrum BIC parameters:                      |, **5**|
 |                                                          |                           |
-| Out of transit factor (% tdur):                          |, **100**| 
-| \+ Out of transit "timing tax" (sec):                    |, **6300**| 
-| Slew duration avg. (sec):                                |, **1800**| 
-| SAMs: small angle maneuvers (sec):                       |, **138**| 
-| GS Acq: guide star acquisition(s)(sec):                  |, **312**| 
-| Targ Acq: target acquisition if any (sec):               |, **62**| 
-| Exposure Ovhd: factor 1:                                 |, **0.0536**| 
-| Exposure Ovhd: factor 2 (sec):                           |, **0**| 
-| Mech: mechanism movements (sec):                         |, **220**| 
-| OSS: Onboard Script System compilation (sec):            |, **58**| 
-| MSA: NIRSpec MSA configuration (sec):                    |, **0**| 
-| IRS2: NIRSpec IRS2 Detector Mode setup (sec):            |, **217**| 
-| Visit Ovhd: visit cleanup activities (sec):              |, **102**| 
-| Obs Ovhd factor (%):                                     |, **16**| 
+| Eq. of State (lo metal atm):                             |, **eos_5Xsolar_cond**|
+| Cloud_lo (Pa):                                           |, **0**|
+| Eq. of State (hi metal atm):                             |, **eos_1000Xsolar_cond**|
+| Cloud_hi (Pa):                                           |, **10000**|
+|                                                          |                           |
+| Out of transit factor (% tdur):                          |, **100**|
+| \+ Out of transit "timing tax" (sec):                    |, **6300**|
+| Slew duration avg. (sec):                                |, **1800**|
+| SAMs: small angle maneuvers (sec):                       |, **138**|
+| GS Acq: guide star acquisition(s)(sec):                  |, **312**|
+| Targ Acq: target acquisition if any (sec):               |, **62**|
+| Exposure Ovhd: factor 1:                                 |, **0.0536**|
+| Exposure Ovhd: factor 2 (sec):                           |, **0**|
+| Mech: mechanism movements (sec):                         |, **220**|
+| OSS: Onboard Script System compilation (sec):            |, **58**|
+| MSA: NIRSpec MSA configuration (sec):                    |, **0**|
+| IRS2: NIRSpec IRS2 Detector Mode setup (sec):            |, **217**|
+| Visit Ovhd: visit cleanup activities (sec):              |, **102**|
+| Obs Ovhd factor (%):                                     |, **16**|
 | DS Ovhd (sec):                                           |, **0**|        
 |                                                          |                           |
-| RunExoT (Y/N):                                           |, **Y**| 
-| RunPdxo (Y/N):                                           |, **Y**| 
-| RunRank (Y/N):                                           |, **Y**| 
+| RunExoT (Y/N):                                           |, **Y**|
+| RunPdxo (Y/N):                                           |, **Y**|
+| RunRank (Y/N):                                           |, **Y**|
 
-  
+
   * The starting and ending rows to analyze from the target_survey.txt file need to be specified.
 
   * The instrument/mode (e.g., NIRSpec G395M) should be selected from the listing (comments further down in the .txt file).  Four of the modes have been tested.  
@@ -287,7 +233,7 @@ The following step-by-step process should guide you through making a run with th
 
   * Sometimes it is useful to bypass certain parts of the code.  For example, if the model atmospheres have already been generated for a batch of targets.  It may makes sense to bypass the ExoT_Master section of the code.  The parameters RunExoT, RunPdxo, and RunRank can be toggled Y or N, to indicate whether or not to bypass that code element.  For a full run we will use all three of these parameters set to Y.
 
- 
+
 4. Next, make sure that the **target\_survey.txt** file in the working directory has the appropriate number of rows for your run.  Various example **target\_survey.txt** files are included in the **Target\_Survey** folder/directory in the repository.  
   * For our example run we will use the full Sullivan survey/catalog **target\_survey\_(Sullivan_survey).txt**.  The **target\_survey.txt** file in the repository is the full Sullivan survey/catalog so for our initial example run you should not need to make changes.
 
@@ -296,7 +242,7 @@ The following step-by-step process should guide you through making a run with th
  ./JET_Master.57.sh
  ```
 
-   * After a few seconds, you should see . . . 
+   * After a few seconds, you should see . . .
 
  ```dos
  !Warning: The starting target value (Nrow_start) is not in sequence.
@@ -307,26 +253,26 @@ The following step-by-step process should guide you through making a run with th
  ```
 6. You should enter **Y** (for the example run we are assuming that you are starting from scratch).
 
-   * After a few seconds, you should see . . . 
+   * After a few seconds, you should see . . .
  ```dos
  Running ExoT_Master:
 
- Reading in survey data . . . 
+ Reading in survey data . . .
 
  Computing model transmission spectra using Exo-Transmit:
 
-      Generating model spectra for target:  5 
+      Generating model spectra for target:  5
 
-      Generating model spectra for target:  6 
+      Generating model spectra for target:  6
 
-      Generating model spectra for target:  7 
+      Generating model spectra for target:  7
 
  Elapsed time for ExoT_Master (sec):  130.65741515159607
 
  !Warning: The starting target value (Nrow_start) is not in sequence.
- 
+
  If you proceed you may overwrite the previous entries.
- 
+
  Proceed with Pdxo? (Y/N):
  ```
 
@@ -338,38 +284,38 @@ The following step-by-step process should guide you through making a run with th
 
  Transferring planetary system data and model spectra to Pandexo . . .
 
-      Generating simulated instrument spectra for target:  5 
+      Generating simulated instrument spectra for target:  5
 
-         Comparing simulation to model spectrum and flat line for lo_metal atm: 
+         Comparing simulation to model spectrum and flat line for lo_metal atm:
 
                min # of transits for mean dBIC (less one sigma) > 10 :  1
 
 
-         Comparing simulation to model spectrum and flat line for hi_metal atm: 
+         Comparing simulation to model spectrum and flat line for hi_metal atm:
 
                mean dBIC (less one sigma) < 10 for 50 transits ---> no detection
 
 
-      Generating simulated instrument spectra for target:  6 
+      Generating simulated instrument spectra for target:  6
 
-         Comparing simulation to model spectrum and flat line for lo_metal atm: 
+         Comparing simulation to model spectrum and flat line for lo_metal atm:
 
                min # of transits for mean dBIC (less one sigma) > 10 :  1
 
 
-         Comparing simulation to model spectrum and flat line for hi_metal atm: 
+         Comparing simulation to model spectrum and flat line for hi_metal atm:
 
                min # of transits for mean dBIC (less one sigma) > 10 :  47
 
 
-      Generating simulated instrument spectra for target:  7 
+      Generating simulated instrument spectra for target:  7
 
-         Comparing simulation to model spectrum and flat line for lo_metal atm: 
+         Comparing simulation to model spectrum and flat line for lo_metal atm:
 
                min # of transits for mean dBIC (less one sigma) > 10 :  1
 
 
-         Comparing simulation to model spectrum and flat line for hi_metal atm: 
+         Comparing simulation to model spectrum and flat line for hi_metal atm:
 
                min # of transits for mean dBIC (less one sigma) > 10 :  11
 
@@ -386,7 +332,7 @@ The following step-by-step process should guide you through making a run with th
 8.  Now we can examine the products of the run.  Two summary tables should have been deposited into the **JET\_Smry_tables** folder/directory.  They are time and date stamped, and named something like: **JET_Smry_20190922-093016_un-ranked**, and **JET_Smry_20190922-093016.txt**.
 
  We can also examine the spectral data tables, and plots that have been deposited into the **Spectra** folder/directory.   For our test run you should see the files listed in Table 4.  
-	
+
  Table 4. Files deposited in **Spectra** folder associated with test run:
 
 | File name                       | Description                                                          |
@@ -409,13 +355,13 @@ The following step-by-step process should guide you through making a run with th
 | Trans_Spec_Xfer_6_lo_metal.txt  | xfer data of re-binned model spectrum for lo-metal atm, targ 6       |
 | Trans_Spec_Xfer_7_hi_metal.txt  | xfer data of re-binned model spectrum for hi-metal atm, targ 7       |
 | Trans_Spec_Xfer_7_lo_metal.txt  | xfer data of re-binned model spectrum for lo-metal atm, targ 7       |
-	
+
  The dBIC-vs-number-of-transits plots have been deposited into the **dBIC** folder/directory.  For our test run you should see only two files (**dBIC_6_hi_metal.svg** and **dBIC_7_hi_metal.svg** ).  Some of the plots may appear to be missing.  They are not really missing, but rather they were not plotted due to a non-detection condition (e.g., saturation, etc.).  
 
  A copy of the **Pdxo_Output.txt** file (with target limits noted **Pdxo_Output_(5 - 7).txt**) has been deposited into the **Pdxo_Output_archive** folder.  This is a copy of the latest appended version of the **Pdxo_Output.txt** file.  This is essentially a backup if anything happens to the raw **Pdxo_Output.txt** file (e.g. an inadvertent overwrite, etc.).   If you are doing a series of runs where the targets are sequential then this file is being appended for each run.  It is over-written if the targets are out of sequence.
 
  You have completed the example run.  Congratulations!
- 
+
 ### Additional Tools
 
 As we've mentioned, the overall JET run time is ~ 3.4 minutes per target (in a single processor mode).  If you are interested in running a large target survey/catalog like "Sullivan" through JET, it is possible to reduce the clock time required by duplicating the JET working directory and splitting the target list.  The process proceeds normally as one instantiation of JET runs the first set of the split list (say from target 1 - 950), and another instantiation of JET runs the other set of the split list (from 951 - 1984).
@@ -433,7 +379,7 @@ Charles Fortenbach
 ## Citations
 When publishing results based on usage of JET please cite:
 
-for JET: 
+for JET:
 Fortenbach, C. D., & Dressing, C. D., 2020, arXiv:2002.01495 (https://ui.adsabs.harvard.edu/abs/2020arXiv200201495F)
 
 and the following dependencies:
@@ -450,19 +396,19 @@ Lupu, R. E., Zahnle, K., Marley, M. S., et al., 2014, ApJ, 784, 27
 PandExo:
 Batalha, N. E., Mandell, A., Pontoppidan, K., et al. 2017, Publications of the Astronomical Society of the Pacific, 129, 064501
 
-astropy: 
+astropy:
 The Astropy Collaboration, Price-Whelan, A. M., Sip}ocz, B. M., et al. 2018, ArXiv e-prints, arXiv:1801.02634
 
-matplotlib: 
+matplotlib:
 Hunter, J. D. 2007, Computing In Science & Engineering, 9, 90
 
-numpy: 
+numpy:
 Oliphant, T. E. 2015, Guide to NumPy, 2nd edn. (USA: CreateSpace Independent Publishing Platform)
 
-scipy: 
+scipy:
 Jones, E., Oliphant, T., Peterson, P., et al. 2001, SciPy: Open source scientific tools for Python
 
-SpectRes: 
+SpectRes:
 Carnall, A. C. 2017, arXiv:1705.05165, 1705.05165v1
 
 ## Version History
@@ -474,7 +420,7 @@ Carnall, A. C. 2017, arXiv:1705.05165, 1705.05165v1
     Update of Pandeia data-files to pandeia_data-1.4.
     Made path values indirect to enable easier portability.
     Modified path to grp directory in shell script for simpler installation.
-    
+
 * 1.1.0 (2019-10-01)
     New routine to handle instrument brightness limits.
     Increased number of model parameters from 4 to 5 for BIC calculation.
@@ -482,7 +428,7 @@ Carnall, A. C. 2017, arXiv:1705.05165, 1705.05165v1
     Various minor corrections and updates.
 
 * 1.2.0 (2019-12-04)
-    Made the number of free model spectrum BIC parameters a user input. 
+    Made the number of free model spectrum BIC parameters a user input.
 
 * 1.3.0 (2020-04-12)
     Updated the calculation of observation time elements, t_dwell and Science_time in Pdxo_Master based on latest STScI guidance.
@@ -496,4 +442,4 @@ Carnall, A. C. 2017, arXiv:1705.05165, 1705.05165v1
 This project is licensed under the GNU GPLv3 License - see the LICENSE.md file for details.
 
 ## Acknowledgments
-The code discussed here was developed as part of C. Fortenbach's Master's thesis project at San Francisco State University. Prof. Courtney Dressing (UC Berkeley) was the thesis advisor on this effort and provided guidance and inspiration throughout.  C.F. would like to acknowledge the support of Prof. Mohsen Janatpour (College of San Mateo), and Profs. Joseph Barranco (SF State Univ.), Andisheh Mahdavi (SF State Univ.), and Stephen Kane (UC Riverside).  We also appreciate the assistance of Josh Lamstein, Shervin Sahba, Dirk Kessler, Paul Seawell, Craig Schuler, and Arjun Savel, who helped with various aspects of the code development.  We are grateful to Prof. Eliza Kempton (Univ. of Maryland) for her guidance on installation and usage of the Exo-Transmit code.  We would like to thank Dr. Tom Greene (NASA Ames) for his insight and guidance on a number of issues.  We would also like to acknowledge the assistance of Dr. Natasha Batalha (UC Santa Cruz) the lead author of the PandExo code. 
+The code discussed here was developed as part of C. Fortenbach's Master's thesis project at San Francisco State University. Prof. Courtney Dressing (UC Berkeley) was the thesis advisor on this effort and provided guidance and inspiration throughout.  C.F. would like to acknowledge the support of Prof. Mohsen Janatpour (College of San Mateo), and Profs. Joseph Barranco (SF State Univ.), Andisheh Mahdavi (SF State Univ.), and Stephen Kane (UC Riverside).  We also appreciate the assistance of Josh Lamstein, Shervin Sahba, Dirk Kessler, Paul Seawell, Craig Schuler, and Arjun Savel, who helped with various aspects of the code development.  We are grateful to Prof. Eliza Kempton (Univ. of Maryland) for her guidance on installation and usage of the Exo-Transmit code.  We would like to thank Dr. Tom Greene (NASA Ames) for his insight and guidance on a number of issues.  We would also like to acknowledge the assistance of Dr. Natasha Batalha (UC Santa Cruz) the lead author of the PandExo code.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# *JWST* Exoplanet Targeting program (JET)
+# *JWST* Exoplanet Targeting program (JET)
 Computer tool to rank lists of exoplanet targets for atmospheric characterization by *JWST*.
 
 ## Description
@@ -35,42 +35,61 @@ The *James Webb Space Telescope* (*JWST*) will devote significant observing time
 
 * The VirtualBox software allows files to be shared between the two OS's, which is very useful, but otherwise it keeps the two systems separate.  In order to implement the file sharing feature it was necessary to edit the system BIOS to enable the CPU's virtualization features.  Unfortunately, the details of the editing are different with different motherboards and CPU hardware so it is hard to give specifics here.  The key is to sort through the BIOS menus at boot up to find the CPU virtualization feature toggle and enable it.  Of course, if the JET suite is installed on a Linux machine in the first place there is no need to worry about virtualization software.
 
-*New*
-* We have used Docker to containerize the required packages for the JET code. Docker will serve a similar purpose in this case as conda environments do, by creating an isolated "container", where all the required package are installed without compromising any existing package dependencies or versions that you already have on your computer. Containers are based off of "images", and in this repo we include the instruction manual (a Dockerfile) for an image that includes the required software to run JET. The following instructions will use this manual to set up the JET code for your use.
+* The JET code was written in Python 3.6.1/2.  It is highly recommended that you use Python 3.6.2 to run JET.
 
-1. Install Docker (https://www.docker.com/products/docker-desktop).
+* JET has a number of Python dependencies (see Table 2); however, many of them will be satisfied by an up-to-date scientific Python installation.  Unless you actively maintain your own scientific Python distribution, we recommend installing the latest Anaconda Linux distribution (currently, as of 7-5-2019, for Python 3.7) and running the following command to downgrade to Python 3.6 in the root environment:
 
-2. Once you have installed Docker, make sure that Docker Desktop (or Server for Linux users) is running.
+ ```conda install python=3.6.2```
 
-3. Next, you need to download certain data-files associated with PandExo/Pandeia.  The first is a set of files for Pandeia itself, which can be downloaded from: https://stsci.app.box.com/v/pandeia-refdata-v1p4.  Once the download is complete, move the tar file from your download folder to the JET/Docker_Files directory of this repository, which should already contain a file named JET_dockerfile.txt.
+* To avoid conflicts, it is recommended that you first remove/uninstall any existing packages shown in Table 2 with the incorrect version/build.  You can see the packages available in your Anaconda distribution with the command:  ```conda list```.
 
-4. Next, you will need to download another set of data-files associated with PandExo.  The second set of data-files are for pysynphot. Pandeia uses pysynphot internally for creating reference spectra. The pysynphot reference files may be downloaded from: https://archive.stsci.edu/pub/hst/pysynphot/.  We want to download **synphot5.tar.gz**.  Move the tar file from your download folder to the JET/Docker_Files directory.  
+* To remove packages that do not have the < pip > designation, you can use the command:
 
-5. In order to use Docker to create a container with the full environment required to run JET, navigate to the JET/Docker_Files directory in your terminal, and enter the command: ```docker build . -f ./JET_dockerfile.txt  -t jet_image``` This command will take ~20 minutes to run, with lots of outputs, and builds a Docker image based on JET_dockerfile.txt. You will create containers on top of this image, in which you can run JET code.
+ ```conda remove package_name```
 
-6. Check whether the image has been created by running ```docker images```, and seeing if one of the images listed is named jet_image.
+* For packages with the < pip > designation, you can use the command:
 
-7. Create a container based on the "jet_image" image with the command ```docker container create -it jet_image```. This step can be repeated every time you wish to use JET, but please note that different containers will not include the same versions of files (i.e. an output file from a JET run in one container will not be present in another container based on the same image).
+ ```pip uninstall package_name```
 
-8. Use ```docker ps -a``` to get a list of all containers, and copy the name of the container you just created (usually two words separated by an underscore, e.g. "adequate_pandas").
+* **Warning!**:  rolling back certain elements of your Python package distribution, may break other Python programs that are dependent on your existing package distribution.  It may make sense to use virtualenv (https://pypi.org/project/virtualenv/), a tool to create isolated Python environments.
 
-9. In order to "enter" a container and run the JET code, you will need to enter two commands: ```docker start CONTAINER``` and then ```docker attach CONTAINER```, where CONTAINER is the name of the container you copied in the step 8. Once you have run these two commands, your terminal will enter the container, where you can now run commands.
+* For those packages that are not included in the basic conda distribution, you will need to enable certain additional distribution channels with:
 
-10. The first command you should run is ```source activate myenv```, in order to use the appropriate python version (Python 3.6.2).
+ ```conda config --add channels conda-forge```
 
-11. Navigate to the JET directory, which should contain the two .tar.gz files. These are in gzip form and can be unpacked in the working directory with the commands:
- ```$ tar -xvzf pandeia_data-1.4.tar.gz```
-```$ tar -xvzf synphot5.tar.gz```
+ and
 
- Once the files are unpacked you should be left with a folder/directory named **pandeia_data-1.4**, **grp**, and the tar files.  The tar files can then be deleted.
+ ```conda config --add channels http://ssb.stsci.edu/astroconda```
 
- Your working directory should now have all of the necessary elements of JET, including all files and folders associated with Exo-Transmit and PandExo. Of course it is possible to download the latest version of Exo-Transmit (source code) from GitHub (see https://github.com/elizakempton/Exo_Transmit), but for simplicity we have chosen to include a fully compiled, and tested version of Exo-Transmit as part of the JET download.  There are also some minor changes to a couple of the baseline Exo-Transmit data-files that we have made for JET to work properly.
+ This only needs to be done once, not for each package.
 
-  In some cases, high-metallicity atmospheres in particular, can be optically thick all the way to the very top of the atmosphere, at certain wavelengths.  This will cause a hard cutoff of the spectrum at a specific transit depth.  To extend the atmosphere to higher levels (i.e., lower pressures), more lines have been added to the original release T-P files (we went from 333 to 533 lines), extending the decaying exponential to lower pressure.  The number of optical depth points given in the file: **otherInput.in**, has also been be modified to give the correct number of lines for the new T-P files.  You should not need to edit these files further.
+* It is recommended that you install the version/build of the packages specified in Table 2. There are various complex dependencies and this build has been verified.  
 
-  There are several input files associated with Exo-Transmit that have not been described in detail (e.g., **selectChem.in**, **otherInput.in**, and **userInput.in**).  For our purposes these should not have to be disturbed by the user; however, it is possible to make changes to these if necessary.  Further details can be found in the Exo-Transmit user manual included in this repository, or at https://github.com/elizakempton/Exo_Transmit.
+* Many of the required packages (unless they have < pip > in the build column of Table 2) can then be installed from the Linux command line with:
 
-12. When this process has been completed for all of the required packages, again use the Linux command ```conda list``` to verify that all packages and modules shown in Table 2 are installed:
+ ```conda install package_name=version=build_string```
+
+ For example:
+
+ ```conda install joblib=0.11=py36_0```
+
+* For those packages with a non-conda channel, you should use the command:
+
+ ```conda install -c channel package_name=version=build_string```
+
+ For example:
+
+ ```conda install -c conda-forge astropy=3.2.3```
+
+ or another example:
+
+ ```conda install -c http://ssb.stsci.edu/astroconda photutils=0.4.1```
+
+* For the remaining packages, you will need to use the pip package manager.  For example, to install numpy use the command:
+
+ ```pip install numpy=1.14.0```
+
+* When this process has been completed for all of the required packages, again use the Linux command ```conda list``` to verify that all packages and modules shown in Table 2 are installed:
 
  Table 2. Python Packages/Modules for JET Installation
 
@@ -92,8 +111,27 @@ The *James Webb Space Telescope* (*JWST*) will devote significant observing time
 | sphinx                | Python pkg.       | 1.5.6                                  | conda-forge                         |
 | synphot               | Python pkg.       | 0.1.3                                  | http://ssb.stsci.edu/astroconda     |
 
+### Installing the JET Code
 
-13. You should also verify that you have all files and folders listed in Table 3 in the JET directory in your container.
+1. Now, choose/create a working directory for the JET code within your Linux system file structure.
+
+2. Open a terminal in your Linux Download directory.  Then, download the JET repository tar file from GitHub with the command:
+
+ ```curl -L https://github.com/cdfortenbach/JET/tarball/master > master```
+
+   This is a big file, so it may take a few minutes.  You should eventually see a folder/directory called **master** appear in the Download directory.
+
+3. Now, unpack the **master** tar file with the command:
+
+ ```tar -xvzf master```
+
+   you should now see a new folder/directory called **cdfortenbach-JET-*commitID#***.   
+
+4. Open this folder/directory and move the contents to your working directory.  
+
+5. The downloaded tar file (**master**), and the now empty folder/directory **cdfortenbach-JET-*commitID#*** can be deleted.  
+
+6. You should verify that you have all files and folders listed in Table 3.
 
  Table 3. Files and Folders in JET Working Directory
 
@@ -124,9 +162,26 @@ The *James Webb Space Telescope* (*JWST*) will devote significant observing time
 | target_survey.txt           | .txt file in format of the "Sullivan" survey .mrt                                        |
 | userInput.in                | internal transfer file assoc. with Exo-Transmit                                          |
 
- You can now interact with the JET code in this container. When you would like to finish using the code, use the command ```exit``` to leave the Docker container and return to your current working directory. When you would like to use the JET code again, please repeat Steps 9-15.
 
-14. It is recommended that the user edit certain print statements in the **PandExo.engine** (installed as a Python package in the Anaconda directory) that are unnecessary and time consuming in our long, many-target runs. Specifically, we recommend that you "comment out" (add leading # character to the line) the following lines in **justdoit.py** and **jwst.py**:
+7. Next, you need to download certain data-files associated with PandExo/Pandeia.  The first is a set of files for Pandeia itself, which can be downloaded from: https://stsci.app.box.com/v/pandeia-refdata-v1p4.  Once the download is complete, move the tar file from your download folder to the JET working directory.  This is in gzip form and can be unpacked in the working directory. Use the command:
+
+ ```$ tar -xvzf pandeia_data-1.4.tar.gz```  
+
+  to unpack the tar file. Once the files are unpacked you should be left with a folder/directory named **pandeia_data-1.4**.  The tar file can then be deleted.
+
+8. Next, you will need to download another set of data-files associated with PandExo.  The second set of data-files are for pysynphot. Pandeia uses pysynphot internally for creating reference spectra. The pysynphot reference files may be downloaded from: https://archive.stsci.edu/pub/hst/pysynphot/.  We want to download **synphot5.tar.gz**.  Move the tar file from your download folder to the JET working directory.  This is also in gzip form and can be unpacked in the working directory with the command:
+
+ ```$ tar -xvzf synphot5.tar.gz```
+
+  Once the files are unpacked you should be left with a folder/directory named **grp** and the tar file.  The tar file can be deleted.
+
+ Your working directory should now have all of the necessary elements of JET, including all files and folders associated with Exo-Transmit and PandExo. Of course it is possible to download the latest version of Exo-Transmit (source code) from GitHub (see https://github.com/elizakempton/Exo_Transmit), but for simplicity we have chosen to include a fully compiled, and tested version of Exo-Transmit as part of the JET download.  There are also some minor changes to a couple of the baseline Exo-Transmit data-files that we have made for JET to work properly.
+
+  In some cases, high-metallicity atmospheres in particular, can be optically thick all the way to the very top of the atmosphere, at certain wavelengths.  This will cause a hard cutoff of the spectrum at a specific transit depth.  To extend the atmosphere to higher levels (i.e., lower pressures), more lines have been added to the original release T-P files (we went from 333 to 533 lines), extending the decaying exponential to lower pressure.  The number of optical depth points given in the file: **otherInput.in**, has also been be modified to give the correct number of lines for the new T-P files.  You should not need to edit these files further.
+
+  There are several input files associated with Exo-Transmit that have not been described in detail (e.g., **selectChem.in**, **otherInput.in**, and **userInput.in**).  For our purposes these should not have to be disturbed by the user; however, it is possible to make changes to these if necessary.  Further details can be found in the Exo-Transmit user manual included in this repository, or at https://github.com/elizakempton/Exo_Transmit.
+
+9. It is recommended that the user edit certain print statements in the **PandExo.engine** (installed as a Python package in the Anaconda directory) that are unnecessary and time consuming in our long, many-target runs. Specifically, we recommend that you "comment out" (add leading # character to the line) the following lines in **justdoit.py** and **jwst.py**:
 
     anconda3/lib/python3.6/site-packages/pandexo/engine/justdoit.py - line 267
     	should be:   ```#print("Running Single Case for: " + inst[0])```
@@ -149,17 +204,16 @@ The *James Webb Space Telescope* (*JWST*) will devote significant observing time
     anconda3/lib/python3.6/site-packages/pandexo/engine/jwst.py - line 178
     	should be:   ```#print("End In Transit")```
 
-15. That’s it!  You have completed the JET installation.
+10. That’s it!  You have completed the JET installation.
 
 
 ### Executing the program
 
 The following step-by-step process should guide you through making a run with the JET code:
 
-1.  First, using a GUI (e.g., Ubuntu, etc.) or with a Linux terminal and Docker commands ```docker start CONTAINER``` and ```docker attach CONTAINER```, navigate to the JET working directory.
+1.  First, using a GUI (e.g., Ubuntu, etc.) or with a Linux terminal, navigate to the JET working directory.
 
-2.  If you want to start fresh, then the folders **dBIC**, **Spectra**, **Pdxo_Output_archive**, and **JET_Smry_tables** should be cleaned out for a new run. Any files in these folders/directories can be saved elsewhere on your local machine as appropriate, by using the command ```docker cp CONTAINER:SRC_PATH DEST_PATH|-``` (https://docs.docker.com/engine/reference/commandline/cp/). The dummy **README** file in each of these folder/directories can be left in place. Alternatively, you can create a new container starting at Step 7 in the Software Installation.
-*endnew*
+2.  If you want to start fresh, then the folders **dBIC**, **Spectra**, **Pdxo_Output_archive**, and **JET_Smry_tables** should be cleaned out for a new run.  Any files in these folders/directories can be saved elsewhere as appropriate. The dummy **README** file in each of these folder/directories can be left in place.
 
 3.  Using a .txt editor (or development environment), open the **JET_Input.txt** file and make the appropriate changes to the input parameters.  The following shows an example set-up for a run with NIRSpec G395M.  Only the boldface parameters should be changed.  Only make changes to User Input values in rows 7 - 46, and cols 60 - 79!!   Do not change the syntax for any item.  This is a comma delimited file.  Commas should only be included where indicated.
 


### PR DESCRIPTION
Adding a Dockerfile which allows a user to create a Docker container with all the specifically required versions of python packages needed to run JET, isolated from their other software installations. Updated README to explain Docker method of installation, pending further changes to incorporate both potential methods of installing the software (manual and Docker). 